### PR TITLE
bump pysam dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ SETUP_METADATA = \
             'bam2fasta = bam2fasta.__main__:main']},
         "install_requires": ["screed>=0.9",
                              "pathos==0.2.5",
-                             "pysam==0.15.3",
+                             "pysam==0.15.4",
                              "tqdm==4.36.1",
                              "numpy==1.16.1"],
         "setup_requires": [


### PR DESCRIPTION
0.15.4 is a bugfix release, but includes support for 3.8 wheels and other improvements:
https://github.com/pysam-developers/pysam/releases/tag/v0.15.4