### PR TITLE
reduce package pysam 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-cython>=0.29.12
 pathos==0.2.5
-pysam==0.15.4
+pysam==0.15.3
 screed==1.0
 tqdm==4.36.1
 codecov==2.0.15

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,9 @@ SETUP_METADATA = \
             'bam2fasta = bam2fasta.__main__:main']},
         "install_requires": ["screed>=0.9",
                              "pathos==0.2.5",
-                             "pysam==0.15.4",
+                             "pysam==0.15.3",
                              "tqdm==4.36.1",
-                             "numpy==1.16.1",
-                             "cython>=0.29.12"],
+                             "numpy==1.16.1"],
         "setup_requires": [
             "setuptools>=38.6.0",
             "setuptools_scm",


### PR DESCRIPTION
https://github.com/pysam-developers/pysam/issues/260#issuecomment-579456185

looks like python 3.6 and python 3.5 are failing due to the htslib.c import for pysam recent version 